### PR TITLE
local can only be used in a bash function

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,6 @@
 # Get a fresh copy of DPLA data
 node run_downloader.js;
 
-local arg from to
 while getopts 'm:r:' arg
 do
     case ${arg} in


### PR DESCRIPTION
`run.sh` attempted to use the `local` keyword outside function context which is not allowed in bash. This thing has not been successfully running on lib-metl-prd-01 in its monthly cron schedule, maybe not ever.

Crons error as

```
X-Cron-Env: <LOGNAME=swadm>
X-Cron-Env: <USER=swadm>
Date: Thu,  1 Apr 2021 00:00:36 -0500 (CDT)
Status: RO

/swadm/opt/haystack_dpla/run.sh: line 6: local: can only be used in a function
```
The current cron incantation should be fine
```
0 0 1 * * rm -rf /swadm/var/www/app/shared/json_data/extractions/dpla_umbra/; mkdir /swadm/var/www/app/shared/json_data/extractions/dpla_umbra/; (cd /swadm/opt/haystack_dpla; /swadm/opt/haystack_dpla/run.sh -m /swadm/var/www/app/shared/json_data/extractions/dpla_umbra/ > /dev/null)
```

@chadfennell From the looks of it, this was last successfully refreshed manually at 3:30pm on Dec 27 2020.

The line declaring `local` vars was not necessary anyway. It included 2 vars `from,to` that weren't actually used, and `arg` could be left implicitly declared by the loop.